### PR TITLE
Move the “Available updates” chinese string

### DIFF
--- a/ShortcutsUpdater.json
+++ b/ShortcutsUpdater.json
@@ -52,9 +52,9 @@
     "menu.available": {
       "US": "Available Updates",
       "RU": "Доступные обновления",
-      "DE": "可用的更新",
+      "DE": "",
       "CH": "可用的更新",
-      "ZH": "",
+      "ZH": "可用的更新",
       "DK": "Tilgængelige Opdateringer"
     },
     "menu.supported": {


### PR DESCRIPTION
When I made that pull request, I didn’t double check the file and just realized that I put the chinese string into the wrong place, sorry